### PR TITLE
Integrate ds2 debug server

### DIFF
--- a/Documentation/Building ds2.md
+++ b/Documentation/Building ds2.md
@@ -1,0 +1,12 @@
+# Building the ds2 Debug Server
+
+The Edge CLI uses the [`ds2` debug server](https://github.com/compnerd/ds2) to debug EdgeOS applications.
+
+The included `ds2` binary was built using the following command:
+
+```sh
+cmake -B out -G Ninja -S . -DSTATIC=ON
+ninja -C out
+```
+
+This builds a static binary that can be used in the containerized environment.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,80 @@
+Apache Edge CLI
+Copyright 2025 Wendy Labs Inc.
+
+This product includes software developed as part of:
+- ds2 (https://github.com/compnerd/ds2)
+
+==============================================================================
+ds2 License:
+==============================================================================
+
+University of Illinois/NCSA Open Source License
+
+Copyright (c) 2014 Facebook, Inc. All rights reserved.
+
+Developed by:
+Facebook, Inc.
+https://code.facebook.com
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal with the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to
+whom the Software is furnished to do so, subject to the following
+conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimers.
+    * Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimers in the
+documentation and/or other materials provided with the distribution.
+    * Neither the names of Facebook, Inc., nor the names of its contributors
+may be used to endorse or promote products derived from this Software without
+specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS WITH THE SOFTWARE.
+
+==============================================================================
+ds2 Additional Patent Grant:
+==============================================================================
+
+Additional Grant of Patent Rights Version 2
+
+"Software" means the ds2 software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook's rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,9 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .target(name: "EdgeCLI"),
                 .product(name: "Logging", package: "swift-log"),
+            ],
+            resources: [
+                .copy("Resources")
             ]
         ),
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,23 @@ swift run --package-path ../../ -- edge run
 
 This will build the Edge CLI and execute it's `run` command. The Edge CLI will in turn build the
 `HelloWorld` example using the Swift Static Linux SDK, and run it in a Docker container.
+
+### Debugging
+
+To debug the `HelloWorld` example, you can use the following command:
+
+```sh
+swift run --package-path ../../ -- edge run --debug
+```
+
+You can now attach the LLDB debugger using port `4242` like this:
+
+```sh
+lldb
+(lldb) target create .build/debug/HelloWorld
+(lldb) settings set target.sdk-path "<path-to-sdk.artifactbundle>/swift-6.0.3-RELEASE_static-linux-0.0.1/swift-linux-musl/musl-1.2.5.sdk/aarch64"
+(lldb) settings set target.swift-module-search-paths "<path-to-sdk.artifactbundle>/swift-6.0.3-RELEASE_static-linux-0.0.1/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static/linux-static"
+(lldb) gdb-remote localhost:4242
+```
+
+Unfortunately, running expressions (e.g. `po`) doesn't work yet.

--- a/Sources/ContainerBuilder/ContainerImageSpec+Layer+File.swift
+++ b/Sources/ContainerBuilder/ContainerImageSpec+Layer+File.swift
@@ -4,13 +4,13 @@ extension ContainerImageSpec.Layer {
     /// Represents a file to be included in a container layer.
     public struct File {
         /// The source URL of the file.
-        public let source: URL
+        public var source: URL
 
         /// The destination path of the file in the container.
-        public let destination: String
+        public var destination: String
 
         /// The permissions to set on the file.
-        public let permissions: UInt16?
+        public var permissions: UInt16?
 
         /// Creates a new container file.
         ///

--- a/Sources/ContainerBuilder/ContainerImageSpec+Layer.swift
+++ b/Sources/ContainerBuilder/ContainerImageSpec+Layer.swift
@@ -4,8 +4,8 @@ extension ContainerImageSpec {
     /// Represents a layer in a container image.
     public struct Layer {
         /// The files to include in this layer.
-        public let files: [File]
-        
+        public var files: [File]
+
         /// Creates a new container layer with the specified files.
         ///
         /// - Parameter files: The files to include in this layer.

--- a/Sources/ContainerBuilder/ContainerImageSpec.swift
+++ b/Sources/ContainerBuilder/ContainerImageSpec.swift
@@ -3,25 +3,25 @@ import Foundation
 /// Represents a container image specification that can be used to build an image.
 public struct ContainerImageSpec {
     /// The CPU architecture for which the image is built.
-    public let architecture: String
+    public var architecture: String
 
     /// The operating system for which the image is built.
-    public let os: String
+    public var os: String
 
     /// The command to run when the container starts.
-    public let cmd: [String]
+    public var cmd: [String]
 
     /// The environment variables for the container.
-    public let env: [String]
+    public var env: [String]
 
     /// The working directory for the container.
-    public let workingDir: String
+    public var workingDir: String
 
     /// The layers that make up the container image.
-    public let layers: [Layer]
+    public var layers: [Layer]
 
     /// The date when the image was created.
-    public let created: Date
+    public var created: Date
 
     /// Creates a new container image specification.
     ///

--- a/Sources/EdgeCLI/SwiftPM.swift
+++ b/Sources/EdgeCLI/SwiftPM.swift
@@ -2,14 +2,14 @@ import Foundation
 import Shell
 
 /// Represents the Swift Package Manager interface for building and managing Swift packages.
-public struct SwiftPM {
+public struct SwiftPM: Sendable {
     public let path: String
 
     public init(path: String = "/usr/bin/swift") {
         self.path = path
     }
 
-    public enum BuildOption {
+    public enum BuildOption: Sendable {
         /// Filter for selecting a specific Swift SDK to build with.
         case swiftSDK(String)
 
@@ -50,10 +50,10 @@ public struct SwiftPM {
 
     /// The return type of the `dumpPackage` method.
     /// Currently incomplete.
-    public struct Package: Decodable {
+    public struct Package: Decodable, Sendable {
         public var targets: [Target]
 
-        public struct Target: Decodable {
+        public struct Target: Decodable, Sendable {
             public var name: String
             public var type: String
         }

--- a/Sources/EdgeCLI/SwiftPM.swift
+++ b/Sources/EdgeCLI/SwiftPM.swift
@@ -16,8 +16,11 @@ public struct SwiftPM: Sendable {
         /// Print the binary output path
         case showBinPath
 
-        /// Built the specified target.
+        /// Build the specified target.
         case target(String)
+
+        /// Build the specified product.
+        case product(String)
 
         case quiet
 
@@ -30,6 +33,8 @@ public struct SwiftPM: Sendable {
                 return ["--show-bin-path"]
             case .target(let target):
                 return ["--target", target]
+            case .product(let product):
+                return ["--product", product]
             case .quiet:
                 return ["--quiet"]
             }

--- a/Sources/Shell/Shell.swift
+++ b/Sources/Shell/Shell.swift
@@ -27,7 +27,7 @@ public enum Shell {
     /// - Returns: A string containing the command's standard output and standard error.
     /// - Throws: An error if the command execution fails
     @discardableResult public static func run(_ arguments: [String]) async throws -> String {
-        logger.info("Executing: \(arguments.joined(separator: " "))")
+        logger.info("Running command", metadata: ["command": .array(arguments.map { .string($0) })])
 
         let process = Process()
 
@@ -99,7 +99,12 @@ public enum Shell {
             }
         } onCancel: {
             // Kill the process when the task is cancelled
-            logger.trace("Task cancelled, terminating process: \(arguments.joined(separator: " "))")
+            logger.trace(
+                "Task cancelled, terminating process",
+                metadata: [
+                    "command": .array(arguments.map { .string($0) })
+                ]
+            )
             process.terminate()
         }
     }

--- a/Sources/edge/Commands/RunCommand.swift
+++ b/Sources/edge/Commands/RunCommand.swift
@@ -38,7 +38,7 @@ struct RunCommand: AsyncParsableCommand {
         }
 
         try await swiftPM.build(
-            .target(executableTarget.name),
+            .product(executableTarget.name),
             .swiftSDK("aarch64-swift-linux-musl")
         )
 

--- a/Sources/edge/Commands/RunCommand.swift
+++ b/Sources/edge/Commands/RunCommand.swift
@@ -102,9 +102,11 @@ struct RunCommand: AsyncParsableCommand {
                 "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", imageName,
                 "ds2", "gdbserver", "0.0.0.0:4242", "/bin/\(executableTarget.name)",
             ])
-        } else {
-            logger.info("Running container", metadata: ["imageName": .string(imageName)])
-            try await Shell.run(["docker", "run", "--rm", imageName])
+            return
         }
+
+        logger.info("Running container", metadata: ["imageName": .string(imageName)])
+        try await Shell.run(["docker", "run", "--rm", imageName])
+
     }
 }


### PR DESCRIPTION
Changes:
- Added a static build of ds2
- Introduced a `--debug` argument to the `edge run` command, which triggers the inclusion of the debug server in the container image
- `Shell` now terminates the child process on Task cancellation
- Changed `swift build` call to pass `--product` instead of `--target`
- Added a section with some notes about attaching lldb to the readme